### PR TITLE
Support for Predicates

### DIFF
--- a/lib/nested_config.rb
+++ b/lib/nested_config.rb
@@ -66,13 +66,13 @@ class NestedConfig
   end
 
   def assign_value(name, *args)
-    key = name.to_s.gsub(/=$/, '')
-    self[key] = args.first
+    sanitized_name = name.to_s.gsub(/=$/, '')
+    self[sanitized_name] = args.first
   end
 
   def has_value?(name, *args)
-    key = name.to_s.gsub(/\?$/, '')
-    respond_to? key
+    sanitized_name = name.to_s.gsub(/\?$/, '')
+    respond_to? sanitized_name
   end
 
   def retrieve_value(name, *args)

--- a/lib/nested_config.rb
+++ b/lib/nested_config.rb
@@ -35,6 +35,8 @@ class NestedConfig
       evaluate_nested_config name, &block
     elsif assigment?(name)
       assign_value name, *args
+    elsif predicate?(name)
+      has_value?(name, *args)
     else
       retrieve_value name, *args
     end
@@ -54,6 +56,10 @@ class NestedConfig
     !name.match(/.*=$/).nil?
   end
 
+  def predicate?(name)
+    !name.match(/.*\?/).nil?
+  end
+
   def evaluate_nested_config(scope_name, &scope)
     config = self[scope_name] ||= self.class.new
     scope.call config
@@ -62,6 +68,11 @@ class NestedConfig
   def assign_value(name, *args)
     key = name.to_s.gsub(/=$/, '')
     self[key] = args.first
+  end
+
+  def has_value?(name, *args)
+    key = name.to_s.gsub(/\?$/, '')
+    respond_to? key
   end
 
   def retrieve_value(name, *args)

--- a/lib/nested_config.rb
+++ b/lib/nested_config.rb
@@ -36,7 +36,7 @@ class NestedConfig
     elsif assigment?(name)
       assign_value name, *args
     elsif predicate?(name)
-      has_value?(name, *args)
+      has_truthy_value?(name, *args)
     else
       retrieve_value name, *args
     end
@@ -70,9 +70,9 @@ class NestedConfig
     self[sanitized_name] = args.first
   end
 
-  def has_value?(name, *args)
+  def has_truthy_value?(name, *args)
     sanitized_name = name.to_s.gsub(/\?$/, '')
-    respond_to? sanitized_name
+    respond_to?(sanitized_name) && !!retrieve_value(sanitized_name, *args)
   end
 
   def retrieve_value(name, *args)

--- a/test/nested_config_test.rb
+++ b/test/nested_config_test.rb
@@ -40,6 +40,15 @@ class NestedConfigTest < NestedConfigSpec
       assert_nil c.unknown
     end
 
+    test "provides predicates for checking key existence" do
+      c = config.tap do |c|
+        c.foo = :bar
+      end
+
+      assert_equal true, c.foo?
+      assert_equal false, c.bar?
+    end
+
     test "sets deep values" do
       c = config.tap do |c|
         c.deep do |deep|

--- a/test/nested_config_test.rb
+++ b/test/nested_config_test.rb
@@ -40,12 +40,14 @@ class NestedConfigTest < NestedConfigSpec
       assert_nil c.unknown
     end
 
-    test "provides predicates for checking key existence" do
+    test "provides predicates for checking truthyness of keys" do
       c = config.tap do |c|
         c.foo = :bar
+        c.falsefoo = false
       end
 
       assert_equal true, c.foo?
+      assert_equal false, c.falsefoo?
       assert_equal false, c.bar?
     end
 


### PR DESCRIPTION
I need support for predicates. We are using `nested_config` as configuration for enabling/disabling features of the current fantasy platform:

``` ruby
Features.configure do |feature|
  feature.galactic_users do |galagctic|
    galactic.enabled = true
    galactic.username_filter = /^hyper_.*/
  end
end

# ...

Features.config.galactic_users.enabled? # => true
Features.config.galactic_users.username_filter  # => /^hyper_.*/

Features.config.auto_commit.enabled? # => false
```
